### PR TITLE
AWS: don't process the management account twice

### DIFF
--- a/aws/aws-resource-counter.py
+++ b/aws/aws-resource-counter.py
@@ -416,6 +416,8 @@ def count_resources(input_type, management_access_key, management_secret_key):
             for account in page['Accounts']:
                 member_account_ids.append(account['Id'])
 
+        member_account_ids.remove(management_account_id)
+
         # Loop through each member account
         for member_account_id in tqdm(member_account_ids, desc="Processing Member Accounts"):
             # Create a new session for each member account by assuming the role


### PR DESCRIPTION
There's already a block for processing the management account at https://github.com/Qualys/totalcloud_resource_counter/blob/main/aws/aws-resource-counter.py#L343.

The current code will ask for account list from Org at https://github.com/Qualys/totalcloud_resource_counter/blob/main/aws/aws-resource-counter.py#L410, however that will also receive the id of the "management account" aka the root of the Organization. As they are not usually set up with the OrganizationAccountAccessRole it will lead to error in logs.
Even if it didn't, it's not really useful to count the same account twice.